### PR TITLE
新增对 YemaPT 作为目标站点的转种适配

### DIFF
--- a/src/config/YemaPT.yaml
+++ b/src/config/YemaPT.yaml
@@ -1,0 +1,101 @@
+url: "https://www.yemapt.org"
+host: www1?.yemapt.org
+siteType: YemaPT
+asSource: false
+asTarget: true
+uploadPath: /#/torrent/add
+seedDomSelector: "form.ant-form"
+needDoubanInfo: false
+name:
+  selector: "#showName"
+subtitle:
+  selector: "#shortDesc"
+description:
+  selector: "#longDesc"
+torrent:
+  selector: "#fileList"
+imdb:
+  selector: "#imdb"
+douban:
+  selector: "#douban"
+poster: "#picture"
+mediaInfo:
+  selector: "#mediaInfo"
+category:
+  selector: "#categoryId"
+  map:
+    movie: "电影"
+    tv: "剧集"
+    tvPack: "剧集"
+    cartoon: "动漫"
+    documentary: "纪录片"
+    variety: "综艺"
+    sport: "体育"
+    app: "软件"
+    game: "游戏"
+    ebook: "书籍"
+    music: "音乐"
+    concert: "MV/演唱会"
+videoType:
+  selector: "#medium"
+  map:
+    uhdbluray: "Blu-rayUHD"
+    bluray: "Blu-ray"
+    remux: "Remux"
+    encode: "Encode"
+    hdtv: "HDTV/TV"
+    web: "Web-dl"
+    dvd: "DVD"
+    dvdrip: "DVDrip"
+videoCodec:
+  selector: "#codec"
+  map:
+    h264: "H.264(x264/AVC)"
+    x264: "H.264(x264/AVC)"
+    hevc: "H.265(x265/HEVC)"
+    h265: "H.265(x265/HEVC)"
+    x265: "H.265(x265/HEVC)"
+    vc1: "Bluray(VC1)"
+    xvid: "Xvid"
+    mpeg2: "MPEG-2"
+    av1: "AV1"
+audioCodec:
+  selector: "#audiocodec"
+  map:
+    aac: "AAC"
+    ac3: "AC3(DD)"
+    dd: "AC3(DD)"
+    dd+: "E-AC3(DDP)"
+    flac: "FLAC"
+    dts: "DTS"
+    truehd: "TrueHD"
+    lpcm: "LPCM"
+    dtshdma: "DTS-HD MA"
+    atmos: "TrueHD Atmos"
+    dtsx: "DTS-HD MA"
+    ape: "APE"
+    wav: "WAV"
+    mp3: "MP3"
+resolution:
+  selector: "#standard"
+  map:
+    2160p: "2160p/4K"
+    1080p: "1080p"
+    1080i: "1080i"
+    720p: "720p"
+    576p: "SD"
+    480p: "SD"
+team:
+  selector: "#team"
+  map:
+    ourbits: "OurBits"
+    btshd: "BtsHD"
+    btstv: "BtsTV"
+    hdchina: "HDChina"
+    cmct: "CMCT"
+    hhweb: "HHWEB"
+    frds: "FRDS"
+    mteam: "MTeam"
+    qhstudio: "QHstudio"
+    ubits: "UBits"
+    other: "Other"

--- a/src/target/index.ts
+++ b/src/target/index.ts
@@ -34,6 +34,7 @@ import './target-filler/iTS';
 import './target-filler/BYR';
 import './target-filler/Pter';
 import './target-filler/MTV';
+import './target-filler/YemaPT';
 import './target-filler/shared-nexusphp-category-change';
 import autofill from './autofill';
 

--- a/src/target/target-filler/YemaPT.ts
+++ b/src/target/target-filler/YemaPT.ts
@@ -1,0 +1,307 @@
+import { getIdByIMDbUrl } from '@/common';
+import { base64ToBlob, getTeamName } from '@/target/helper/index';
+import { BaseFiller } from './base/base-filler';
+import { registry, TargetFiller } from './registry';
+
+type ReactFiberNode = {
+  child?: ReactFiberNode;
+  sibling?: ReactFiberNode;
+  stateNode?: {
+    state?: unknown;
+    context?: {
+      setFieldsValue?: (fields: Record<string, unknown>) => void;
+    };
+  };
+};
+
+class YemaPT extends BaseFiller implements TargetFiller {
+  priority = 10;
+
+  canHandle(siteName: string): boolean {
+    return siteName === 'YemaPT';
+  }
+
+  fill(info: TorrentInfo.Info): void {
+    this.info = info;
+    window.addEventListener(
+      'torrentAddPageReady',
+      () => {
+        this.fillYemaPTForm();
+      },
+      { once: true },
+    );
+  }
+
+  private fillYemaPTForm(): void {
+    const instance = this.getAntFormInstance();
+    const setFieldsValue = instance?.context?.setFieldsValue;
+    if (!setFieldsValue || !this.info) {
+      console.warn('YemaPT form instance was not found');
+      return;
+    }
+
+    setFieldsValue.call(instance.context, this.buildFields());
+    this.fillTorrentFileByForm(setFieldsValue.bind(instance.context));
+    this.fillSelects();
+  }
+
+  private getAntFormInstance() {
+    const antForm = document.querySelector('form.ant-form');
+    if (!antForm) return null;
+
+    const fiber = this.getReactFiberNode(antForm);
+    return this.getReactComponentInstance(fiber);
+  }
+
+  private getReactFiberNode(element: Element): ReactFiberNode | null {
+    for (const key in element) {
+      if (key.startsWith('__reactFiber')) {
+        return (element as unknown as Record<string, ReactFiberNode>)[key];
+      }
+    }
+    return null;
+  }
+
+  private getReactComponentInstance(fiberNode: ReactFiberNode | null) {
+    if (fiberNode?.stateNode?.state !== undefined) {
+      return fiberNode.stateNode;
+    }
+
+    let child = fiberNode?.child;
+    while (child) {
+      const instance = this.getReactComponentInstance(child);
+      if (instance) return instance;
+      child = child.sibling;
+    }
+
+    return null;
+  }
+
+  private buildFields(): Record<string, unknown> {
+    const info = this.info!;
+    const fields: Record<string, unknown> = {
+      showName: info.title,
+      shortDesc: info.subtitle || '',
+      longDesc: this.bbcodeToMarkdown(info.description),
+    };
+
+    const picture = this.getPoster();
+    if (picture) fields.picture = picture;
+
+    const doubanId = info.doubanUrl?.match(/subject\/(\d+)/)?.[1];
+    if (doubanId) fields.douban = doubanId;
+
+    const imdbId = getIdByIMDbUrl(info.imdbUrl || '').replace(/^tt/i, '');
+    if (imdbId) fields.imdb = imdbId;
+
+    const mediaInfo = info.mediaInfos?.[0];
+    if (mediaInfo) fields.mediaInfo = mediaInfo;
+
+    return fields;
+  }
+
+  private getPoster(): string {
+    const { poster, description } = this.info!;
+    if (poster) return poster;
+    return description.match(/\[img\]([^[]+?)\[\/img\]/i)?.[1]?.trim() || '';
+  }
+
+  private bbcodeToMarkdown(text: string): string {
+    return text
+      .replace(/\[size=\d\]/gi, '')
+      .replace(/\[\/size\]/gi, '')
+      .replace(/\[font=.+?\]/gi, '')
+      .replace(/\[\/font\]/gi, '')
+      .replace(/\[color=.+?\]/gi, '')
+      .replace(/\[\/color\]/gi, '')
+      .replace(/\[img\](.*?)\[\/img\]/gi, '![_]($1)')
+      .replace(/\[b\]\s*/gi, '**')
+      .replace(/\s*\[\/b\]/gi, '**')
+      .replace(/\[i\]\s*/gi, '*')
+      .replace(/\s*\[\/i\]/gi, '*')
+      .replace(/\[url=([^\]]*?)\](.*?)\[\/url\]/gi, '[$2]($1)')
+      .replace(/\[quote\]([\s\S]*?)\[\/quote\]/gi, (_match, quote) => {
+        return `> ${quote.split('\n').join('\n> ')}\n\n`;
+      });
+  }
+
+  private fillTorrentFileByForm(
+    setFieldsValue: (fields: Record<string, unknown>) => void,
+  ): void {
+    const { torrentData, title } = this.info!;
+    if (!torrentData) return;
+
+    const blob = base64ToBlob(torrentData);
+    const torrentFileName = title
+      .replace(/^\[.*?\](\.| )?/, '')
+      .replace(/\s/g, '.');
+    const file = new File([blob], `${torrentFileName}.torrent`, {
+      type: 'application/x-bittorrent',
+    }) as File & { originFileObj?: File };
+
+    file.originFileObj = file;
+    setFieldsValue({ fileList: [file] });
+  }
+
+  private async fillSelects(): Promise<void> {
+    const sequence = [
+      ['medium', 0, this.getVideoType()],
+      ['standard', 1, this.getResolution()],
+      ['codec', 2, this.getVideoCodec()],
+      ['audiocodec', 3, this.getAudioCodec()],
+      ['regionList', 4, this.getRegions()],
+      ['team', 5, this.getTeam()],
+      ['tagList', 6, this.getTags()],
+      ['categoryId', 7, this.getCategory()],
+    ] as const;
+
+    for (const [id, index, value] of sequence) {
+      await this.selectDropdownOption(id, index, value);
+    }
+  }
+
+  private getCategory(): string {
+    const map = this.siteInfo.category?.map ?? {};
+    return (map[this.info!.category] as string) || '未分类';
+  }
+
+  private getVideoType(): string {
+    const { videoType } = this.info!;
+    return (this.siteInfo.videoType?.map?.[videoType] as string) || 'Other';
+  }
+
+  private getResolution(): string {
+    const { resolution } = this.info!;
+    return (this.siteInfo.resolution?.map?.[resolution] as string) || 'Other';
+  }
+
+  private getVideoCodec(): string {
+    const { videoCodec = '', videoType } = this.info!;
+    if (
+      /^(h264|x264)$/i.test(videoCodec) &&
+      /^(bluray|uhdbluray)$/i.test(videoType)
+    ) {
+      return 'Bluray(AVC)';
+    }
+    if (
+      /^(hevc|h265|x265)$/i.test(videoCodec) &&
+      /^(bluray|uhdbluray)$/i.test(videoType)
+    ) {
+      return 'Bluray(HEVC)';
+    }
+    return (this.siteInfo.videoCodec?.map?.[videoCodec] as string) || 'Other';
+  }
+
+  private getAudioCodec(): string {
+    const { audioCodec = '', title } = this.info!;
+    if (/^(ac3|dd|\+?dd)$/i.test(audioCodec) && /DDP|DD\+/i.test(title)) {
+      return /Atmos/i.test(title) ? 'E-AC3 Atmos' : 'E-AC3(DDP)';
+    }
+    return (this.siteInfo.audioCodec?.map?.[audioCodec] as string) || 'Other';
+  }
+
+  private getRegions(): string[] {
+    const area = this.info!.area;
+    const areaMap: Record<string, string> = {
+      CN: 'CN(中国)',
+      HK: 'HK/CN(香港)',
+      TW: 'TW/CN(台湾)',
+      JP: 'JP(日本)',
+      KR: 'KR(韩国)',
+      US: 'US(美国)',
+      EU: 'EU(欧洲)',
+      UK: 'UK(英国)',
+      CA: 'CA(加拿大)',
+      AU: 'AU(澳大利亚)',
+    };
+
+    return area && areaMap[area] ? [areaMap[area]] : ['Other'];
+  }
+
+  private getTeam(): string {
+    const teamName = getTeamName(this.info!.title)?.toLowerCase();
+    if (!teamName) return 'Other';
+    return (this.siteInfo.team?.map?.[teamName] as string) || 'Other';
+  }
+
+  private getTags(): string[] {
+    const { tags, title } = this.info!;
+    const result: string[] = [];
+    if (tags.chinese_audio) result.push('国语');
+    if (tags.chinese_subtitle) result.push('中字');
+    if (tags.cantonese_audio) result.push('粤语');
+    if (tags.hdr10 || tags.hdr10_plus) result.push('HDR10');
+    if (tags.dolby_vision) result.push('杜比视界');
+    if (/E\d+/i.test(title)) result.push('分集');
+    if (/complete|S\d{2}(?!E\d{2})/i.test(title)) result.push('完结');
+    return result;
+  }
+
+  private async selectDropdownOption(
+    id: string,
+    index: number,
+    targetTitle: string | string[],
+  ): Promise<void> {
+    if (
+      !targetTitle ||
+      (Array.isArray(targetTitle) && targetTitle.length === 0)
+    ) {
+      return;
+    }
+
+    const element = document.getElementById(id);
+    if (!element) return;
+
+    element.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    const listHolder = await this.waitForListHolder(index);
+    if (!listHolder) return;
+
+    const titles = Array.isArray(targetTitle) ? targetTitle : [targetTitle];
+    for (const title of titles) {
+      await this.clickOption(listHolder, title);
+    }
+  }
+
+  private async waitForListHolder(index: number): Promise<Element | null> {
+    for (let i = 0; i < 10; i += 1) {
+      await this.sleep(200);
+      const listHolder = document.querySelectorAll('.rc-virtual-list-holder')[
+        index
+      ];
+      if (listHolder) return listHolder;
+    }
+    return null;
+  }
+
+  private async clickOption(listHolder: Element, title: string): Promise<void> {
+    const findAndClick = () => {
+      const option = Array.from(
+        listHolder.querySelectorAll<HTMLElement>('.ant-select-item-option'),
+      ).find((item) => item.getAttribute('title') === title);
+      if (!option) return false;
+      option.click();
+      return true;
+    };
+
+    if (findAndClick()) return;
+
+    const holder = listHolder as HTMLElement;
+    let currentScroll = 0;
+    let totalHeight = holder.scrollHeight;
+    holder.scrollTop = 0;
+
+    while (currentScroll < totalHeight) {
+      holder.scrollTop += 100;
+      currentScroll += 100;
+      await this.sleep(100);
+      if (findAndClick()) return;
+      totalHeight = holder.scrollHeight;
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+registry.register(new YemaPT());

--- a/vite.config.js
+++ b/vite.config.js
@@ -79,6 +79,8 @@ export default defineConfig({
           'https://hd-space.org/index.php?page=torrent-details&id=*',
           'https://speedapp.io/browse/*',
           'https://*.m-team.cc/detail/*',
+          'https://www.yemapt.org/*',
+          'https://www1.yemapt.org/*',
         ],
         exclude: [
           'https://*/torrent/peers*',


### PR DESCRIPTION
## 主要改动

  - 新增 `YemaPT.yaml` 站点配置，包含上传入口、域名匹配、字段选择器，以及分类、媒介、编码等映射。
  - 新增专用 `YemaPT` target filler。
  - 通过监听 YemaPT 页面派发的 `torrentAddPageReady` 事件触发表单填充，避免在表单未初始化完成时写入失败。
  - 通过 Ant Design / React 表单实例的 `setFieldsValue` 填充：
    - 标题
    - 副标题
    - 简介
    - 海报
    - 豆瓣 ID
    - IMDb ID
    - MediaInfo
    - torrent 文件
  - 增加媒介、分辨率、视频编码、音频编码、地区、制作组、标签、分类等下拉项填充。
  - 增加 userscript 匹配规则：
    - `https://www.yemapt.org/*`
    - `https://www1.yemapt.org/*`

  ## 验证

  - `yarn exec eslint src/target/target-filler/YemaPT.ts src/target/index.ts vite.config.js`
  - `yarn build`
  - 提交钩子已通过 staged 文件的 lint 和相关测试。