### PR TITLE
fix: 修复 YemaPT 描述处理时 mediaInfo 为空导致的报错

### DIFF
--- a/src/target/target-filler/YemaPT.test.ts
+++ b/src/target/target-filler/YemaPT.test.ts
@@ -55,6 +55,16 @@ describe('YemaPT target filler helpers', () => {
     ).toBe('简介');
   });
 
+  it('ignores null media info entries when cleaning description', () => {
+    const mediaInfo = 'General\nComplete name: demo.mkv';
+    const malformedInfo = {
+      description: `简介\n[quote]${mediaInfo}[/quote]`,
+      mediaInfos: [null, undefined, '   ', mediaInfo],
+    } as unknown as Parameters<typeof prepareYemaPTDescription>[0];
+
+    expect(prepareYemaPTDescription(malformedInfo)).toBe('简介');
+  });
+
   it('gets season number from common torrent title patterns', () => {
     expect(getYemaPTSeason('Show.Name.S02E03.1080p.WEB-DL')).toBe(2);
     expect(getYemaPTSeason('Show Name Season 03 2160p WEB-DL')).toBe(3);

--- a/src/target/target-filler/YemaPT.ts
+++ b/src/target/target-filler/YemaPT.ts
@@ -26,7 +26,11 @@ export const prepareYemaPTDescription = (
   let description = filterEmptyTags(info.description || '').replace(/^\s+/, '');
 
   info.mediaInfos?.forEach((mediaInfo) => {
-    description = description.replace(mediaInfo.trim(), '');
+    const normalizedMediaInfo =
+      typeof mediaInfo === 'string' ? mediaInfo.trim() : '';
+    if (!normalizedMediaInfo) return;
+
+    description = description.replace(normalizedMediaInfo, '');
   });
 
   description = description.replace(


### PR DESCRIPTION
## 变更说明

  这个 PR 修复了 YemaPT 目标站点在处理简介时的一个运行时错误。

  此前 `prepareYemaPTDescription` 会直接对 `mediaInfos` 中的每一项调用 `trim()`。当数组中出现 `null`、`undefined` 或空字符串时，会触发以下报错：

  ```text
  Uncaught TypeError: Cannot read properties of null (reading 'trim')

  本次修改为 mediaInfo 增加了保护逻辑，只有在其为非空字符串时才执行替换处理。

  ## 修改内容

  - 修复 prepareYemaPTDescription 对空 mediaInfo 直接调用 trim() 的问题
  - 跳过 null、undefined 和空白 mediaInfos 项
  - 补充回归测试，覆盖异常 mediaInfos 输入场景

  ## 问题现象

  实际报错如下：

  Uncaught TypeError: Cannot read properties of null (reading 'trim')

  ## 验证情况

  - 已补充对应回归测试