### PR TITLE
feat: support torrentUrl handoff

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,5 +1,6 @@
 export * from './image';
 export * from './media';
 export * from './movie';
+export * from './torrent-file';
 export * from './torrent-info';
 export * from './utils';

--- a/src/common/torrent-file.test.ts
+++ b/src/common/torrent-file.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import parseTorrent, { toTorrentFile } from 'parse-torrent';
+import { Buffer } from 'buffer/index.js';
+import {
+  sanitizeTorrentBuffer,
+  sanitizeTorrentToDataUrl,
+} from './torrent-file';
+
+const createTorrentBuffer = () =>
+  toTorrentFile({
+    info: {
+      name: 'example.txt',
+      length: 7,
+      'piece length': 16384,
+      pieces: Buffer.alloc(20),
+      source: 'source-site',
+    },
+    announce: ['https://source.example/announce'],
+    comment: 'source comment',
+  });
+
+describe('torrent-file', () => {
+  it('sanitizes torrent announce, comment, and source', async () => {
+    const sanitized = await sanitizeTorrentBuffer(
+      createTorrentBuffer().buffer,
+      'https://target.example/announce',
+    );
+    const parsed = await parseTorrent(Buffer.from(sanitized));
+
+    expect(parsed.announce).toEqual(['https://target.example/announce']);
+    expect(parsed.comment || '').toBe('');
+    expect(parsed.info.source).toHaveLength(0);
+  });
+
+  it('throws when target announce is missing', async () => {
+    await expect(
+      sanitizeTorrentBuffer(createTorrentBuffer().buffer),
+    ).rejects.toThrow('Missing torrent announce URL');
+  });
+
+  it('returns sanitized torrent data url', async () => {
+    const dataUrl = await sanitizeTorrentToDataUrl(
+      createTorrentBuffer().buffer,
+      'https://target.example/announce',
+    );
+
+    expect(dataUrl).toMatch(/^data:application\/x-bittorrent;base64,/);
+  });
+});

--- a/src/common/torrent-file.ts
+++ b/src/common/torrent-file.ts
@@ -1,0 +1,47 @@
+import parseTorrent, { toTorrentFile } from 'parse-torrent';
+import { Buffer } from 'buffer/index.js';
+
+export const TORRENT_CONTENT_TYPE = 'application/x-bittorrent';
+
+const arrayBufferToDataUrl = (
+  buffer: ArrayBuffer | Uint8Array,
+  contentType = TORRENT_CONTENT_TYPE,
+): string => {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = '';
+
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(offset, offset + chunkSize),
+    );
+  }
+
+  return `data:${contentType};base64,${window.btoa(binary)}`;
+};
+
+export const sanitizeTorrentBuffer = async (
+  buffer: ArrayBuffer,
+  announce?: string,
+) => {
+  if (!announce) {
+    throw new Error('Missing torrent announce URL');
+  }
+
+  const parsed = await parseTorrent(Buffer.from(buffer));
+
+  return toTorrentFile({
+    ...parsed,
+    comment: '',
+    announce: [announce],
+    info: {
+      ...parsed.info,
+      source: '',
+    },
+  });
+};
+
+export const sanitizeTorrentToDataUrl = async (
+  buffer: ArrayBuffer,
+  announce?: string,
+) => arrayBufferToDataUrl(await sanitizeTorrentBuffer(buffer, announce));

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import { fillTargetForm } from './target';
 import { getTorrentInfo } from '@/source';
 import { fillSearchImdb } from './site-dom/quick-search';
 import { torrentInfoStore } from '@/store/torrentInfoStore';
+import { hydrateTorrentDataFromUrl } from '@/target/helper';
 import './site-dom/analyze-upload-page';
 import './style.css';
 import App from './components/Container';
@@ -222,7 +223,10 @@ async function initialize() {
   if (CURRENT_SITE_INFO.asTarget) {
     const torrentInfo = await retrieveTorrentInfo();
     if (torrentInfo) {
-      fillTargetForm(torrentInfo as TorrentInfo.Info);
+      const hydratedInfo = await hydrateTorrentDataFromUrl(
+        torrentInfo as TorrentInfo.Info,
+      );
+      fillTargetForm(hydratedInfo);
     }
   }
 

--- a/src/source/helper.ts
+++ b/src/source/helper.ts
@@ -1,6 +1,4 @@
-import parseTorrent, { toTorrentFile } from 'parse-torrent';
-import { GMFetch, $t } from '../common';
-import { Buffer } from 'buffer/index.js';
+import { GMFetch, $t, sanitizeTorrentToDataUrl } from '../common';
 import { CURRENT_SITE_INFO, PT_SITE, SiteName } from '@/const';
 import { toast } from 'sonner';
 import $ from 'jquery';
@@ -26,19 +24,6 @@ const getFormat = (data: string) => {
   return 'other';
 };
 
-const blobToBase64 = (blob: Blob): Promise<string> => {
-  return new Promise((resolve, reject) => {
-    const fileReader = new FileReader();
-    fileReader.onload = (e) => {
-      resolve(e.target?.result as string);
-    };
-    fileReader.readAsDataURL(blob);
-    fileReader.onerror = () => {
-      reject(new Error('blobToBase64 error'));
-    };
-  });
-};
-
 const getTorrentFileData = async (
   selector = '',
   torrentLink = '',
@@ -60,21 +45,9 @@ const getTorrentFileData = async (
       responseType: 'arraybuffer',
       timeout: 10000,
     });
-    const result = parseTorrent(Buffer.from(file));
     const siteInfo = PT_SITE[targetSiteName as SiteName] as Site.SiteInfo;
-    const announceUrl = siteInfo?.torrent?.announce || 'tracker.com';
-    const buf = toTorrentFile({
-      ...result,
-      comment: '',
-      announce: [announceUrl],
-      info: {
-        ...result.info,
-        source: '',
-      },
-    });
-    const blob = new Blob([buf], { type: 'application/x-bittorrent' });
-    const base64 = await blobToBase64(blob);
-    return base64;
+    const announceUrl = siteInfo?.torrent?.announce;
+    return sanitizeTorrentToDataUrl(file, announceUrl);
   } catch (error) {
     toast.error(
       `${$t('error.torrentDownloadFailed')} ${$t('error.torrentDownloadManual')}`,

--- a/src/target/helper/index.ts
+++ b/src/target/helper/index.ts
@@ -1,3 +1,35 @@
+import {
+  GMFetch,
+  sanitizeTorrentToDataUrl,
+  TORRENT_CONTENT_TYPE,
+} from '@/common';
+import { CURRENT_SITE_INFO } from '@/const';
+
+export const hydrateTorrentDataFromUrl = async (
+  info: TorrentInfo.Info,
+): Promise<TorrentInfo.Info> => {
+  if (info.torrentData || !info.torrentUrl) {
+    return info;
+  }
+
+  try {
+    const torrentFile = await GMFetch<ArrayBuffer>(info.torrentUrl, {
+      method: 'GET',
+      responseType: 'arraybuffer',
+      timeout: 10000,
+    });
+    const announceUrl = CURRENT_SITE_INFO?.torrent?.announce;
+
+    return {
+      ...info,
+      torrentData: await sanitizeTorrentToDataUrl(torrentFile, announceUrl),
+    };
+  } catch (error) {
+    console.error('fail to fetch torrent from torrentUrl', error);
+    return info;
+  }
+};
+
 /**
  * transform base64 string to blob
  *
@@ -8,7 +40,7 @@
  */
 export const base64ToBlob = (
   base64: string,
-  contentType = 'application/x-bittorrent',
+  contentType = TORRENT_CONTENT_TYPE,
   sliceSize = 512,
 ): Blob => {
   const regStr = new RegExp(`data:${contentType};base64,`, 'i');

--- a/src/target/helper/tests/index.test.ts
+++ b/src/target/helper/tests/index.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import parseTorrent, { toTorrentFile } from 'parse-torrent';
+import { Buffer } from 'buffer/index.js';
+import { GMFetch } from '@/common/utils';
+import { hydrateTorrentDataFromUrl } from '@/target/helper';
+
+vi.mock('@/common/utils', () => ({
+  GMFetch: vi.fn(),
+}));
+
+vi.mock('@/const', () => ({
+  CURRENT_SITE_INFO: {
+    torrent: {
+      announce: 'https://target.example/announce',
+    },
+  },
+}));
+
+const createTorrentInfo = (
+  overrides: Partial<TorrentInfo.Info> = {},
+): TorrentInfo.Info => ({
+  title: 'Example.Movie.2026.1080p',
+  description: 'description',
+  year: '2026',
+  category: 'movie',
+  videoType: 'encode',
+  source: 'Blu-ray',
+  resolution: '1080p',
+  mediaInfos: [],
+  screenshots: [],
+  movieName: 'Example Movie',
+  sourceSite: 'Differential',
+  sourceSiteType: 'NexusPHP',
+  size: 1024,
+  tags: {},
+  ...overrides,
+});
+
+const createTorrentBuffer = () =>
+  toTorrentFile({
+    info: {
+      name: 'example.txt',
+      length: 7,
+      'piece length': 16384,
+      pieces: Buffer.alloc(20),
+      source: 'source-site',
+    },
+    announce: ['https://source.example/announce'],
+    comment: 'source comment',
+  });
+
+const parseTorrentDataUrl = (dataUrl: string) =>
+  parseTorrent(Buffer.from(dataUrl.split(',')[1], 'base64'));
+
+describe('hydrateTorrentDataFromUrl', () => {
+  beforeEach(() => {
+    vi.mocked(GMFetch).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps existing torrentData without fetching torrentUrl', async () => {
+    const info = createTorrentInfo({
+      torrentData: 'data:application/x-bittorrent;base64,existing',
+      torrentUrl: 'http://127.0.0.1:8765/torrent/example.torrent',
+    });
+
+    const result = await hydrateTorrentDataFromUrl(info);
+
+    expect(result).toBe(info);
+    expect(result.torrentData).toBe(
+      'data:application/x-bittorrent;base64,existing',
+    );
+    expect(GMFetch).not.toHaveBeenCalled();
+  });
+
+  it('fetches torrentUrl and stores it as torrentData', async () => {
+    vi.mocked(GMFetch).mockResolvedValueOnce(createTorrentBuffer().buffer);
+
+    const info = createTorrentInfo({
+      torrentUrl: 'http://127.0.0.1:8765/torrent/example.torrent',
+    });
+
+    const result = await hydrateTorrentDataFromUrl(info);
+
+    expect(GMFetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:8765/torrent/example.torrent',
+      {
+        method: 'GET',
+        responseType: 'arraybuffer',
+        timeout: 10000,
+      },
+    );
+    expect(result).not.toBe(info);
+    expect(result.torrentData).toMatch(
+      /^data:application\/x-bittorrent;base64,/,
+    );
+    const parsed = await parseTorrentDataUrl(result.torrentData as string);
+    expect(parsed.announce).toEqual(['https://target.example/announce']);
+    expect(parsed.comment || '').toBe('');
+    expect(parsed.info.source).toHaveLength(0);
+  });
+
+  it('returns the original torrent info when torrentUrl fetch fails', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const error = new Error('failed to fetch torrent');
+    vi.mocked(GMFetch).mockRejectedValueOnce(error);
+    const info = createTorrentInfo({
+      torrentUrl: 'http://127.0.0.1:8765/torrent/example.torrent',
+    });
+
+    const result = await hydrateTorrentDataFromUrl(info);
+
+    expect(result).toBe(info);
+    expect(result.torrentData).toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      'fail to fetch torrent from torrentUrl',
+      error,
+    );
+  });
+});

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -89,6 +89,7 @@ declare namespace TorrentInfo {
     hardcodedSub?: boolean; // 是否包含硬字幕
     doubanBookInfo?: BookInfo;
     torrentData?: string;
+    torrentUrl?: string;
     musicJson?: {
       group: MusicJson.GroupInfo;
       torrent: MusicJson.Torrent;

--- a/vite.config.js
+++ b/vite.config.js
@@ -50,6 +50,7 @@ const userscriptPlugins = [
         en: 'Transfer torrents between trackers with one click.',
       },
       namespace: 'https://github.com/xheiop/easy-upload',
+      connect: ['127.0.0.1', 'localhost'],
       match: [
         'http*://*/torrents.php?id=*',
         'http*://*/torrents.php?torrentid=*',


### PR DESCRIPTION
## 变更内容

  - 支持在 `torrentInfo` 中传入 `torrentUrl`
  - 当目标站点填表时，如果没有 `torrentData` 但存在 `torrentUrl`，会自动下载种子并转成现有的 `torrentData` 格式
  - 复用原有的种子文件 input 填充逻辑
  - 添加 `127.0.0.1` / `localhost` 的 userscript `@connect` 配置
  - 增加相关单元测试