### PR TITLE
fix: 从简介中兜底提取豆瓣和 IMDb 链接

### DIFF
--- a/src/source/index.ts
+++ b/src/source/index.ts
@@ -1,5 +1,6 @@
 import { CURRENT_SITE_INFO, CURRENT_SITE_NAME } from '@/const';
 import { registry } from './info-extractors/registry';
+import { applyExternalIdFallbacks } from './info-fallback';
 
 import './info-extractors/nexusphp';
 import './info-extractors/PTer';
@@ -46,7 +47,7 @@ export async function getTorrentInfo(): Promise<TorrentInfo.Info | null> {
   }
 
   try {
-    return await extractor.extract();
+    return applyExternalIdFallbacks(await extractor.extract());
   } catch (error) {
     console.log('Error extracting torrent info', error);
     return null;

--- a/src/source/info-fallback.test.ts
+++ b/src/source/info-fallback.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { applyExternalIdFallbacks } from './info-fallback';
+
+const buildInfo = (info: Partial<TorrentInfo.Info>): TorrentInfo.Info =>
+  ({
+    title: '',
+    description: '',
+    doubanInfo: '',
+    doubanUrl: '',
+    imdbUrl: '',
+    screenshots: [],
+    tags: {},
+    mediaInfos: [],
+    ...info,
+  }) as TorrentInfo.Info;
+
+describe('source external id fallbacks', () => {
+  it('fills missing douban and imdb URLs from description', () => {
+    const info = applyExternalIdFallbacks(
+      buildInfo({
+        description:
+          '◎IMDb链接 https://www.imdb.com/title/tt11630814/\n◎豆瓣链接 [url=https://movie.douban.com/subject/34951007/]豆瓣[/url]',
+      }),
+    );
+
+    expect(info.doubanUrl).toBe('https://movie.douban.com/subject/34951007/');
+    expect(info.imdbUrl).toBe('https://www.imdb.com/title/tt11630814/');
+  });
+
+  it('fills missing IDs from doubanInfo', () => {
+    const info = applyExternalIdFallbacks(
+      buildInfo({
+        doubanInfo:
+          '◎IMDb链接 tt7654321\n◎豆瓣链接 https://book.douban.com/subject/123456/',
+      }),
+    );
+
+    expect(info.doubanUrl).toBe('https://book.douban.com/subject/123456/');
+    expect(info.imdbUrl).toBe('https://www.imdb.com/title/tt7654321/');
+  });
+
+  it('keeps existing source URLs', () => {
+    const info = applyExternalIdFallbacks(
+      buildInfo({
+        doubanUrl: 'https://movie.douban.com/subject/111111/',
+        imdbUrl: 'https://www.imdb.com/title/tt1111111/',
+        description:
+          'https://movie.douban.com/subject/222222/ https://www.imdb.com/title/tt2222222/',
+      }),
+    );
+
+    expect(info.doubanUrl).toBe('https://movie.douban.com/subject/111111/');
+    expect(info.imdbUrl).toBe('https://www.imdb.com/title/tt1111111/');
+  });
+});

--- a/src/source/info-fallback.ts
+++ b/src/source/info-fallback.ts
@@ -1,0 +1,34 @@
+const getDoubanUrlFromText = (text: string): string => {
+  const match = text.match(
+    /https?:\/\/((?:movie|book)\.)?douban\.com\/subject\/(\d+)/i,
+  );
+  if (!match) return '';
+
+  const host = match[1] === 'book.' ? 'book.douban.com' : 'movie.douban.com';
+  return `https://${host}/subject/${match[2]}/`;
+};
+
+const getIMDbUrlFromText = (text: string): string => {
+  const id =
+    text.match(/https?:\/\/(?:www\.)?imdb\.com\/title\/(tt\d{5,13})/i)?.[1] ||
+    text.match(/\b(tt\d{5,13})\b/i)?.[1] ||
+    '';
+
+  return id ? `https://www.imdb.com/title/${id.toLowerCase()}/` : '';
+};
+
+export const applyExternalIdFallbacks = (
+  info: TorrentInfo.Info,
+): TorrentInfo.Info => {
+  const text = `${info.description || ''}\n${info.doubanInfo || ''}`;
+
+  if (!info.doubanUrl) {
+    info.doubanUrl = getDoubanUrlFromText(text);
+  }
+
+  if (!info.imdbUrl) {
+    info.imdbUrl = getIMDbUrlFromText(text);
+  }
+
+  return info;
+};


### PR DESCRIPTION
## 变更说明

  当源站接口或页面字段没有直接提供豆瓣 / IMDb 链接时，增加统一兜底逻辑，从已提取到的简介内容中尝试解析：

  - 豆瓣链接：匹配 `movie.douban.com/subject/<id>` 或 `book.douban.com/subject/<id>`
  - IMDb 链接：匹配 IMDb title 链接或裸 `tt` 编号

  该逻辑接入在 `getTorrentInfo()` 返回前，对所有源站 extractor 生效，避免每个站点单独补类似逻辑。

  ## 修复场景

  部分源站详情接口中豆瓣字段为空，但简介里实际包含豆瓣链接，导致转发到目标站时无法填充豆瓣 ID。

  ## 测试

  - `corepack yarn test src/source/info-fallback.test.ts --run`
  - pre-commit: eslint + related vitest