### PR TITLE
修复 YemaPT 类目映射填充

### DIFF
--- a/src/config/YemaPT.yaml
+++ b/src/config/YemaPT.yaml
@@ -25,18 +25,23 @@ mediaInfo:
 category:
   selector: "#categoryId"
   map:
-    movie: "电影"
-    tv: "剧集"
-    tvPack: "剧集"
-    cartoon: "动漫"
-    documentary: "纪录片"
-    variety: "综艺"
-    sport: "体育"
-    app: "软件"
-    game: "游戏"
-    ebook: "书籍"
-    music: "音乐"
-    concert: "MV/演唱会"
+    movie: 4
+    tv: 5
+    tvPack: 5
+    variety: 13
+    cartoon: 14
+    documentary: 15
+    concert: 16
+    sport: 17
+    app: 3
+    game: 10
+    ebook: 12
+    music: 8
+    audiobook: 9
+    onlineCourse: 21
+    magazine: 22
+    comics: 22
+    other: 22
 videoType:
   selector: "#medium"
   map:

--- a/src/target/target-filler/YemaPT.test.ts
+++ b/src/target/target-filler/YemaPT.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   bbcodeToMarkdown,
+  getYemaPTCategory,
   getYemaPTSeason,
+  isYemaPTOptionMatch,
   prepareYemaPTDescription,
 } from './YemaPT';
 
@@ -70,5 +72,37 @@ describe('YemaPT target filler helpers', () => {
     expect(getYemaPTSeason('Show Name Season 03 2160p WEB-DL')).toBe(3);
     expect(getYemaPTSeason('剧名 第4季 1080p WEB-DL')).toBe(4);
     expect(getYemaPTSeason('Movie.Name.2024.1080p.BluRay')).toBeNull();
+  });
+
+  it('maps HH movie category to YemaPT category value', () => {
+    expect(getYemaPTCategory('movie', { movie: 4 })).toBe(4);
+    expect(getYemaPTCategory('unknown', { movie: 4 })).toBe(0);
+  });
+
+  it('maps extended YemaPT category values', () => {
+    const categoryMap = {
+      app: 3,
+      game: 10,
+      ebook: 12,
+      music: 8,
+      audiobook: 9,
+      onlineCourse: 21,
+      other: 22,
+    };
+
+    expect(getYemaPTCategory('app', categoryMap)).toBe(3);
+    expect(getYemaPTCategory('game', categoryMap)).toBe(10);
+    expect(getYemaPTCategory('ebook', categoryMap)).toBe(12);
+    expect(getYemaPTCategory('music', categoryMap)).toBe(8);
+    expect(getYemaPTCategory('audiobook', categoryMap)).toBe(9);
+    expect(getYemaPTCategory('onlineCourse', categoryMap)).toBe(21);
+    expect(getYemaPTCategory('other', categoryMap)).toBe(22);
+  });
+
+  it('matches YemaPT dropdown options by title or visible text', () => {
+    expect(isYemaPTOptionMatch('电影', '', '电影')).toBe(true);
+    expect(isYemaPTOptionMatch('', '电影 / Movies', '电影')).toBe(true);
+    expect(isYemaPTOptionMatch('Movies', '电影', '电影')).toBe(true);
+    expect(isYemaPTOptionMatch('剧集', '剧集', '电影')).toBe(false);
   });
 });

--- a/src/target/target-filler/YemaPT.ts
+++ b/src/target/target-filler/YemaPT.ts
@@ -55,6 +55,27 @@ export const getYemaPTSeason = (title: string): number | null => {
     : null;
 };
 
+export const getYemaPTCategory = (
+  category: string,
+  categoryMap: Record<string, unknown> = {},
+): unknown => {
+  return categoryMap[category] ?? 0;
+};
+
+export const isYemaPTOptionMatch = (
+  optionTitle: string,
+  optionText: string,
+  targetTitle: string,
+): boolean => {
+  const target = targetTitle.trim();
+  const title = optionTitle.trim();
+  const text = optionText.trim();
+
+  if (!target) return false;
+  if (title === target || text === target) return true;
+  return title.includes(target) || text.includes(target);
+};
+
 const convertQuoteToMarkdown = (quote: string, title = ''): string => {
   const normalized = quote.trim();
   if (!normalized) return '';
@@ -220,6 +241,8 @@ class YemaPT extends BaseFiller implements TargetFiller {
     const season = getYemaPTSeason(info.title);
     if (season) fields.season = season;
 
+    fields.categoryId = this.getCategory();
+
     return fields;
   }
 
@@ -256,7 +279,6 @@ class YemaPT extends BaseFiller implements TargetFiller {
       ['regionList', 4, this.getRegions()],
       ['team', 5, this.getTeam()],
       ['tagList', 6, this.getTags()],
-      ['categoryId', 7, this.getCategory()],
     ] as const;
 
     for (const [id, index, value] of sequence) {
@@ -264,9 +286,9 @@ class YemaPT extends BaseFiller implements TargetFiller {
     }
   }
 
-  private getCategory(): string {
+  private getCategory(): unknown {
     const map = this.siteInfo.category?.map ?? {};
-    return (map[this.info!.category] as string) || '未分类';
+    return getYemaPTCategory(this.info!.category, map);
   }
 
   private getVideoType(): string {
@@ -390,8 +412,16 @@ class YemaPT extends BaseFiller implements TargetFiller {
   private async clickOption(listHolder: Element, title: string): Promise<void> {
     const findAndClick = () => {
       const option = Array.from(
-        listHolder.querySelectorAll<HTMLElement>('.ant-select-item-option'),
-      ).find((item) => item.getAttribute('title') === title);
+        listHolder.querySelectorAll<HTMLElement>(
+          '.ant-select-item-option, .ant-cascader-menu-item',
+        ),
+      ).find((item) =>
+        isYemaPTOptionMatch(
+          item.getAttribute('title') || '',
+          item.textContent || '',
+          title,
+        ),
+      );
       if (!option) return false;
       option.click();
       return true;


### PR DESCRIPTION
## 变更说明

  修复转种到 YemaPT 时类目未正确映射的问题。

  ## 主要改动

  - 将 YemaPT 类目映射改为后端实际使用的 categoryId value
  - 通过 YemaPT 表单实例直接设置 categoryId，避免二层类目 UI 选择失败
  - 补全 YemaPT 后端类目映射，包括影视、综合、音频、教育相关分类
  - 增加 YemaPT 类目映射相关测试

  ## 验证

  - `corepack yarn vitest run src/target/target-filler/YemaPT.test.ts`
  - pre-commit 自动执行 eslint 和相关 vitest 通过