### PR TITLE
修复 YemaPT 表单下拉字段填充值错误

### DIFF
--- a/src/target/target-filler/YemaPT.test.ts
+++ b/src/target/target-filler/YemaPT.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   bbcodeToMarkdown,
+  getYemaPTOptionValue,
   getYemaPTSeason,
   prepareYemaPTDescription,
 } from './YemaPT';
@@ -70,5 +71,17 @@ describe('YemaPT target filler helpers', () => {
     expect(getYemaPTSeason('Show Name Season 03 2160p WEB-DL')).toBe(3);
     expect(getYemaPTSeason('剧名 第4季 1080p WEB-DL')).toBe(4);
     expect(getYemaPTSeason('Movie.Name.2024.1080p.BluRay')).toBeNull();
+  });
+
+  it('maps YemaPT select labels to real option values', () => {
+    expect(getYemaPTOptionValue('category', '电影')).toBe(4);
+    expect(getYemaPTOptionValue('medium', 'Web-DL/WebRip')).toBe('1');
+    expect(getYemaPTOptionValue('standard', '4K/2160p')).toBe('7');
+    expect(getYemaPTOptionValue('codec', 'Bluray(HEVC)')).toBe('5');
+    expect(getYemaPTOptionValue('audiocodec', 'E-AC3 Atmos')).toBe('6');
+    expect(getYemaPTOptionValue('region', 'CN(中国)')).toBe('1');
+    expect(getYemaPTOptionValue('team', 'MTeam')).toBe('8');
+    expect(getYemaPTOptionValue('tag', '杜比全景声(Atmos)')).toBe('15');
+    expect(getYemaPTOptionValue('medium', '1')).toBe('1');
   });
 });

--- a/src/target/target-filler/YemaPT.ts
+++ b/src/target/target-filler/YemaPT.ts
@@ -25,6 +25,158 @@ type TorrentAddPageReadyEventDetail = {
   form?: YemaPTFormInstance;
 };
 
+type YemaPTOptionValue = string | number;
+type YemaPTSelectOptionKey =
+  | 'category'
+  | 'medium'
+  | 'standard'
+  | 'codec'
+  | 'audiocodec'
+  | 'region'
+  | 'team'
+  | 'tag';
+
+const YEMAPT_SELECT_VALUE_MAP: Record<
+  YemaPTSelectOptionKey,
+  Record<string, YemaPTOptionValue>
+> = {
+  category: {
+    未分类: 0,
+    软件: 3,
+    电影: 4,
+    剧集: 5,
+    短剧: 6,
+    音乐: 8,
+    广播剧: 9,
+    游戏: 10,
+    书籍: 12,
+    综艺: 13,
+    动漫: 14,
+    纪录片: 15,
+    'MV/演唱会': 16,
+    体育: 17,
+    其他: 22,
+  },
+  medium: {
+    'Web-DL/WebRip': '1',
+    'Blu-ray (1080p Complete)': '2',
+    'Blu-ray UHD (4K Complete)': '3',
+    Remux: '4',
+    'Rip/Encode': '5',
+    'HDTV/TV Cap': '6',
+    DVDRip: '7',
+    DVDrip: '7',
+    'Audio CD/Vinyl': '8',
+    'DVD (Complete/ISO)': '9',
+    Other: '999',
+  },
+  standard: {
+    '720i': '1',
+    '720p': '2',
+    '1080i': '3',
+    '1080p': '4',
+    SD: '5',
+    '2K/1440p': '6',
+    '4K/2160p': '7',
+    '8K': '8',
+    Other: '999',
+  },
+  codec: {
+    'H.264/AVC': '1',
+    'H.265/HEVC': '2',
+    'VC-1(Blu-ray)': '3',
+    'Bluray(AVC)': '4',
+    'Bluray(HEVC)': '5',
+    'MPEG-2(Blu-ray/DVD)': '6',
+    'Xvid/DivX': '7',
+    AV1: '8',
+    VP9: '9',
+    'H.266/VVC': '10',
+    Other: '999',
+  },
+  audiocodec: {
+    AAC: '1',
+    'AC3 (Dolby Digital)': '2',
+    DTS: '3',
+    'DTS-HD MA': '4',
+    'E-AC3 (Dolby Digital Plus)': '5',
+    'E-AC3 Atmos': '6',
+    TrueHD: '7',
+    'TrueHD Atmos': '8',
+    LPCM: '9',
+    FLAC: '10',
+    APE: '11',
+    MP3: '12',
+    OGG: '13',
+    Opus: '14',
+    Other: '999',
+  },
+  region: {
+    'CN(中国)': '1',
+    'HK/CN(香港)': '2',
+    'TW/CN(台湾)': '3',
+    'US(美国)': '4',
+    'EU(欧洲)': '5',
+    'JP(日本)': '6',
+    'KR(韩国)': '7',
+    Other: '999',
+  },
+  team: {
+    OurBits: '1',
+    BtsHD: '2',
+    BtsTV: '3',
+    HDChina: '4',
+    CMCT: '5',
+    HHWEB: '6',
+    FRDS: '7',
+    MTeam: '8',
+    QHstudio: '9',
+    UBits: '10',
+    Other: '999',
+  },
+  tag: {
+    禁转: '1',
+    首发: '2',
+    官组: '3',
+    DIY: '4',
+    国语: '5',
+    中字: '6',
+    粤语: '7',
+    英字: '8',
+    HDR10: '9',
+    杜比视界: '10',
+    连载中: '11',
+    完结: '12',
+    多国字幕: '13',
+    'HDR10+': '14',
+    '杜比全景声(Atmos)': '15',
+    'DTS-X': '16',
+    '5.1/7.1声道': '17',
+    完结全集: '18',
+    'SP/剧场版/OVA': '19',
+  },
+};
+
+export const getYemaPTOptionValue = (
+  key: YemaPTSelectOptionKey,
+  labelOrValue: YemaPTOptionValue,
+): YemaPTOptionValue => {
+  const optionMap = YEMAPT_SELECT_VALUE_MAP[key];
+  const normalizedValue = String(labelOrValue);
+
+  if (Object.prototype.hasOwnProperty.call(optionMap, normalizedValue)) {
+    return optionMap[normalizedValue];
+  }
+
+  return labelOrValue;
+};
+
+const getYemaPTOptionValues = (
+  key: YemaPTSelectOptionKey,
+  labelsOrValues: YemaPTOptionValue[],
+): YemaPTOptionValue[] =>
+  labelsOrValues.map((labelOrValue) => getYemaPTOptionValue(key, labelOrValue));
+
 export const prepareYemaPTDescription = (
   info: Pick<TorrentInfo.Info, 'description' | 'mediaInfos'>,
 ): string => {
@@ -228,17 +380,17 @@ class YemaPT extends BaseFiller implements TargetFiller {
 
   private buildSelectFields(): Record<string, unknown> {
     const fields: Record<string, unknown> = {
-      medium: this.getVideoType(),
-      standard: this.getResolution(),
-      codec: this.getVideoCodec(),
-      audiocodec: this.getAudioCodec(),
-      regionList: this.getRegions(),
-      team: this.getTeam(),
-      categoryId: this.getCategory(),
+      medium: getYemaPTOptionValue('medium', this.getVideoType()),
+      standard: getYemaPTOptionValue('standard', this.getResolution()),
+      codec: getYemaPTOptionValue('codec', this.getVideoCodec()),
+      audiocodec: getYemaPTOptionValue('audiocodec', this.getAudioCodec()),
+      regionList: getYemaPTOptionValues('region', this.getRegions()),
+      team: getYemaPTOptionValue('team', this.getTeam()),
+      categoryId: getYemaPTOptionValue('category', this.getCategory()),
     };
 
     const tags = this.getTags();
-    if (tags.length > 0) fields.tagList = tags;
+    if (tags.length > 0) fields.tagList = getYemaPTOptionValues('tag', tags);
 
     return fields;
   }


### PR DESCRIPTION
## 变更说明

  修复 YemaPT 发布页自动填充时，`setFieldsValue` 写入下拉字段展示名称而不是真实 option value 的问题。

  本次将分类、媒介、分辨率、视频编码、音频编码、地区、制作组和标签字段统一转换为 YemaPT 表单实际需要的 value 后再填充。

  ## 验证

  - `corepack yarn vitest run src/target/target-filler/YemaPT.test.ts`
  - pre-commit: `eslint` 和相关测试通过