### PR TITLE
fix: 优化 YemaPT 图片与截图字段填充

### DIFF
--- a/src/source/info-extractors/hanhan.ts
+++ b/src/source/info-extractors/hanhan.ts
@@ -113,10 +113,16 @@ class HanHanExtractor extends NexusPHPExtractor {
   }
 
   extractPoster() {
-    this.info.poster = $('#cover-content')?.attr('src') ?? '';
+    const coverContent = $('#cover-content');
+    const poster =
+      coverContent.attr('src') ||
+      coverContent.find('img').first().attr('src') ||
+      '';
+    this.info.poster = poster;
   }
 
   async extractDescription() {
+    this.extractPoster();
     this.extractDoubanUrl();
     this.extractImdbUrl();
     this.extractMetaInfo();

--- a/src/target/target-filler/YemaPT.test.ts
+++ b/src/target/target-filler/YemaPT.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   bbcodeToMarkdown,
+  buildYemaPTScreenshotList,
   getYemaPTPicture,
   getYemaPTOptionValue,
   getYemaPTSeason,
@@ -67,6 +68,25 @@ describe('YemaPT target filler helpers', () => {
     expect(prepareYemaPTDescription(malformedInfo)).toBe('简介');
   });
 
+  it('removes known screenshot images from long description', () => {
+    const screenshot = 'https://example.com/screenshot.jpg';
+    const otherImage = 'https://example.com/poster.jpg';
+
+    expect(
+      prepareYemaPTDescription({
+        description: [
+          '简介',
+          `[img=350x350]${screenshot}[/img]`,
+          `[url=https://example.com][img]${screenshot}[/img][/url]`,
+          screenshot,
+          `[img]${otherImage}[/img]`,
+        ].join('\n'),
+        mediaInfos: [],
+        screenshots: [screenshot],
+      }),
+    ).toBe(`简介\n[img]${otherImage}[/img]`);
+  });
+
   it('gets season number from common torrent title patterns', () => {
     expect(getYemaPTSeason('Show.Name.S02E03.1080p.WEB-DL')).toBe(2);
     expect(getYemaPTSeason('Show Name Season 03 2160p WEB-DL')).toBe(3);
@@ -106,5 +126,16 @@ describe('YemaPT target filler helpers', () => {
         screenshots: ['https://example.com/screenshot.jpg'],
       } as TorrentInfo.Info),
     ).toBe('https://example.com/poster.jpg');
+  });
+
+  it('builds YemaPT screenshotList from screenshot urls', () => {
+    expect(
+      buildYemaPTScreenshotList([
+        ' https://example.com/a.jpg ',
+        '',
+        '   ',
+        'https://example.com/b.jpg',
+      ]),
+    ).toEqual(['https://example.com/a.jpg', 'https://example.com/b.jpg']);
   });
 });

--- a/src/target/target-filler/YemaPT.test.ts
+++ b/src/target/target-filler/YemaPT.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   bbcodeToMarkdown,
+  getYemaPTPicture,
   getYemaPTOptionValue,
   getYemaPTSeason,
   prepareYemaPTDescription,
@@ -83,5 +84,27 @@ describe('YemaPT target filler helpers', () => {
     expect(getYemaPTOptionValue('team', 'MTeam')).toBe('8');
     expect(getYemaPTOptionValue('tag', '杜比全景声(Atmos)')).toBe('15');
     expect(getYemaPTOptionValue('medium', '1')).toBe('1');
+  });
+
+  it('does not use a known screenshot as YemaPT picture fallback', () => {
+    const screenshot = 'https://example.com/screenshot.jpg';
+
+    expect(
+      getYemaPTPicture({
+        poster: '',
+        description: `[img]${screenshot}[/img]`,
+        screenshots: [screenshot],
+      } as TorrentInfo.Info),
+    ).toBe('');
+  });
+
+  it('uses explicit poster before YemaPT picture fallback', () => {
+    expect(
+      getYemaPTPicture({
+        poster: 'https://example.com/poster.jpg',
+        description: '[img]https://example.com/screenshot.jpg[/img]',
+        screenshots: ['https://example.com/screenshot.jpg'],
+      } as TorrentInfo.Info),
+    ).toBe('https://example.com/poster.jpg');
   });
 });

--- a/src/target/target-filler/YemaPT.ts
+++ b/src/target/target-filler/YemaPT.ts
@@ -177,6 +177,24 @@ const getYemaPTOptionValues = (
 ): YemaPTOptionValue[] =>
   labelsOrValues.map((labelOrValue) => getYemaPTOptionValue(key, labelOrValue));
 
+export const getYemaPTPicture = (
+  info: Pick<TorrentInfo.Info, 'poster' | 'description' | 'screenshots'>,
+): string => {
+  const { poster, description, screenshots = [] } = info;
+  if (poster) return poster;
+
+  const firstDescriptionImage =
+    description.match(/\[img\]([^[]+?)\[\/img\]/i)?.[1]?.trim() || '';
+  if (!firstDescriptionImage) return '';
+
+  const normalizedScreenshots = screenshots.map((screenshot) =>
+    screenshot.trim(),
+  );
+  return normalizedScreenshots.includes(firstDescriptionImage)
+    ? ''
+    : firstDescriptionImage;
+};
+
 export const prepareYemaPTDescription = (
   info: Pick<TorrentInfo.Info, 'description' | 'mediaInfos'>,
 ): string => {
@@ -329,7 +347,7 @@ class YemaPT extends BaseFiller implements TargetFiller {
       longDesc: bbcodeToMarkdown(prepareYemaPTDescription(info)),
     };
 
-    const picture = this.getPoster();
+    const picture = getYemaPTPicture(info);
     if (picture) fields.picture = picture;
 
     const doubanId = info.doubanUrl?.match(/subject\/(\d+)/)?.[1];
@@ -345,12 +363,6 @@ class YemaPT extends BaseFiller implements TargetFiller {
     if (season) fields.season = season;
 
     return fields;
-  }
-
-  private getPoster(): string {
-    const { poster, description } = this.info!;
-    if (poster) return poster;
-    return description.match(/\[img\]([^[]+?)\[\/img\]/i)?.[1]?.trim() || '';
   }
 
   private fillTorrentFileByForm(

--- a/src/target/target-filler/YemaPT.ts
+++ b/src/target/target-filler/YemaPT.ts
@@ -195,8 +195,39 @@ export const getYemaPTPicture = (
     : firstDescriptionImage;
 };
 
+const escapeRegExp = (text: string): string =>
+  text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const removeYemaPTScreenshotImages = (
+  description: string,
+  screenshots: TorrentInfo.Info['screenshots'] = [],
+): string => {
+  let result = description;
+  buildYemaPTScreenshotList(screenshots).forEach((screenshot) => {
+    const escapedScreenshot = escapeRegExp(screenshot);
+    const wrappedScreenshotImage =
+      `\\[url=[^\\]]*?\\][ \\t]*` +
+      `\\[img(?:=[^\\]]*?)?\\][ \\t]*${escapedScreenshot}[ \\t]*` +
+      `\\[\\/img\\][ \\t]*\\[\\/url\\]`;
+    const screenshotImage =
+      `\\[img(?:=[^\\]]*?)?\\][ \\t]*${escapedScreenshot}[ \\t]*` +
+      `\\[\\/img\\]`;
+    result = result
+      .replace(
+        new RegExp(`^[ \\t]*${wrappedScreenshotImage}[ \\t]*\\n?`, 'gim'),
+        '',
+      )
+      .replace(new RegExp(`^[ \\t]*${screenshotImage}[ \\t]*\\n?`, 'gim'), '')
+      .replace(new RegExp(`^[ \\t]*${escapedScreenshot}[ \\t]*\\n?`, 'gim'), '')
+      .replace(new RegExp(wrappedScreenshotImage, 'gi'), '')
+      .replace(new RegExp(screenshotImage, 'gi'), '');
+  });
+  return result;
+};
+
 export const prepareYemaPTDescription = (
-  info: Pick<TorrentInfo.Info, 'description' | 'mediaInfos'>,
+  info: Pick<TorrentInfo.Info, 'description' | 'mediaInfos'> &
+    Partial<Pick<TorrentInfo.Info, 'screenshots'>>,
 ): string => {
   let description = filterEmptyTags(info.description || '').replace(/^\s+/, '');
 
@@ -213,8 +244,17 @@ export const prepareYemaPTDescription = (
     '',
   );
 
+  description = removeYemaPTScreenshotImages(description, info.screenshots);
+
   return filterEmptyTags(description).trim();
 };
+
+export const buildYemaPTScreenshotList = (
+  screenshots: TorrentInfo.Info['screenshots'] = [],
+): string[] =>
+  screenshots
+    .map((screenshot) => screenshot.trim())
+    .filter((screenshot) => screenshot.length > 0);
 
 export const getYemaPTSeason = (title: string): number | null => {
   const season =
@@ -358,6 +398,9 @@ class YemaPT extends BaseFiller implements TargetFiller {
 
     const mediaInfo = info.mediaInfos?.[0];
     if (mediaInfo) fields.mediaInfo = mediaInfo;
+
+    const screenshotList = buildYemaPTScreenshotList(info.screenshots);
+    if (screenshotList.length > 0) fields.screenshotList = screenshotList;
 
     const season = getYemaPTSeason(info.title);
     if (season) fields.season = season;


### PR DESCRIPTION
## 变更说明

  本 PR 优化 YemaPT 转种时的图片处理逻辑：

  - 修复 HH 来源截图被误填入 YemaPT 主图 `picture` 的问题
  - 适配 YemaPT 新增的 `screenshotList` 字段，自动填入截图列表
  - 当截图已填入 `screenshotList` 后，从简介中移除对应截图图片，避免重复展示
  - 保留非截图图片，避免误删海报或其他介绍图
  - 增加 YemaPT 相关单元测试覆盖

  ## 测试

  - `corepack yarn vitest run src/target/target-filler/YemaPT.test.ts`
  - pre-commit: `eslint --max-warnings 0`
  - pre-commit: `vitest related --run`