### PR TITLE
修复描述引用块中 MediaInfo 识别失败的问题

### DIFF
--- a/src/source/helper/index.test.ts
+++ b/src/source/helper/index.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { getBDInfoOrMediaInfoFromBBCode } from '.';
+
+describe('getBDInfoOrMediaInfoFromBBCode', () => {
+  it('recognizes a sectioned MediaInfo without identifying fields', () => {
+    const mediaInfo = [
+      'General',
+      'Complete name : demo.mkv',
+      'Format : Matroska',
+      '',
+      'Video',
+      'Format : AVC',
+      'Width : 1 920 pixels',
+      '',
+      'Audio',
+      'Format : AAC LC',
+      'Channel(s) : 2 channels',
+    ].join('\n');
+
+    expect(
+      getBDInfoOrMediaInfoFromBBCode(`[quote]${mediaInfo}[/quote]`),
+    ).toEqual({ bdInfo: [], mediaInfo: [mediaInfo] });
+  });
+
+  it('recognizes MediaInfo containing square brackets', () => {
+    const mediaInfo = [
+      'General',
+      'Unique ID : 261661174147273455199166502268741581595',
+      '',
+      'Video',
+      'Codec ID : V_MPEG4/ISO/AVC',
+      '',
+      'Audio',
+      'Codec ID : A_DTS',
+      '',
+      'Text #1',
+      'Title : 简体中文&English [MT机翻]',
+    ].join('\n');
+
+    expect(
+      getBDInfoOrMediaInfoFromBBCode(`[quote]${mediaInfo}[/quote]`),
+    ).toEqual({ bdInfo: [], mediaInfo: [mediaInfo] });
+  });
+
+  it('does not treat an ordinary quote mentioning sections as MediaInfo', () => {
+    const quote = 'General information about Video and Audio';
+
+    expect(getBDInfoOrMediaInfoFromBBCode(`[quote]${quote}[/quote]`)).toEqual({
+      bdInfo: [],
+      mediaInfo: [],
+    });
+  });
+});

--- a/src/source/helper/index.ts
+++ b/src/source/helper/index.ts
@@ -132,15 +132,16 @@ export const getBDInfoOrMediaInfoFromBBCode = (
   bbcode: string,
 ): { bdInfo: string[]; mediaInfo: string[] } => {
   const quoteList: string[] = [];
-  const quoteRegex = /\[quote\]([^[\]])+?\[\/quote\]/gi;
-  while (bbcode?.match(quoteRegex)?.length) {
-    const matchContent = bbcode?.match(quoteRegex)?.[0] ?? '';
-    quoteList.push(matchContent);
-    bbcode = bbcode.replace(matchContent, '');
+  const quoteRegex = /\[quote(?:=[^\]]*)?\][\s\S]*?\[\/quote\]/gi;
+  let quoteMatch: RegExpExecArray | null;
+  while ((quoteMatch = quoteRegex.exec(bbcode)) !== null) {
+    quoteList.push(quoteMatch[0]);
   }
+  bbcode = bbcode.replace(quoteRegex, '');
   const cleanQuoteContent = (quote: string) =>
     quote
-      .replace(/\[\/?quote\]/g, '')
+      .replace(/^\[quote(?:=[^\]]*)?\]/i, '')
+      .replace(/\[\/quote\]$/i, '')
       .replace(/\u200D/g, '')
       .trim();
 
@@ -148,8 +149,31 @@ export const getBDInfoOrMediaInfoFromBBCode = (
     /Disc\s?Size|\.mpls/i.test(content) ||
     /Disc\s+(Info|Title|Label)[^[]+/i.test(content);
 
-  const isMediaInfo = (content: string) =>
-    /(Unique\s*ID)|(Codec\s*ID)|(Stream\s*size)/i.test(content);
+  const isMediaInfo = (content: string) => {
+    if (/(Unique\s*ID)|(Codec\s*ID)|(Stream\s*size)/i.test(content)) {
+      return true;
+    }
+
+    // Some MediaInfo outputs omit the identifying fields above. In that case,
+    // recognize the standard section order instead of leaving the whole dump as
+    // an ordinary quote.
+    const sectionNames = content
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) =>
+        /^(General|Video(?:\s*#\d+)?|Audio(?:\s*#\d+)?)$/i.test(line),
+      )
+      .map((line) => line.match(/^[A-Za-z]+/)?.[0].toLowerCase());
+    const generalIndex = sectionNames.indexOf('general');
+    const videoIndex = sectionNames.indexOf('video');
+    const audioIndex = sectionNames.indexOf('audio');
+
+    return (
+      generalIndex !== -1 &&
+      videoIndex > generalIndex &&
+      audioIndex > videoIndex
+    );
+  };
 
   const { bdInfo, mediaInfo } = quoteList.reduce(
     (acc, quote) => {


### PR DESCRIPTION
## 修改说明

  修复从描述引用块中提取 MediaInfo 失败的问题。该修改作用于公共 MediaInfo 提取逻辑，适用于所有使用此逻辑解析描述的站点。

  ## 问题原因

  原有引用块正则不允许内容中出现 `[` 或 `]`。当 MediaInfo 包含类似以下内容时，整个引用块无法被提取：

  ```text
  Title : 简体中文&English [MT机翻]

  此外，原有 MediaInfo 判断主要依赖 Unique ID、Codec ID 和 Stream size 等字段。部分缺少这些字段、但具有标准分段结构的 MediaInfo 也可能无法识别。

  ## 修改内容

  - 支持提取内容中包含方括号的 [quote] 引用块
  - 支持 [quote=标题] 格式
  - 支持通过 General → Video → Audio 标准分段结构识别 MediaInfo
  - 保留原有特征字段识别逻辑
  - 避免将普通引用误判为 MediaInfo
  - 增加包含方括号内容及标准分段结构的回归测试

  ## 影响范围

  所有调用公共 getBDInfoOrMediaInfoFromBBCode 方法、从描述引用块中提取 MediaInfo 的源站解析器。

  ## 验证结果

  - ESLint 检查通过
  - 相关测试全部通过
  - 生产构建通过